### PR TITLE
Environment variable on launch just for Navi cards

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -172,7 +172,12 @@ else
         then	    
             export TORCH_COMMAND="pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/rocm5.2"
         fi
-        HSA_OVERRIDE_GFX_VERSION=10.3.0 exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
+        if echo "$gpu_info" | grep -q "Navi"
+        then
+            HSA_OVERRIDE_GFX_VERSION=10.3.0 exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
+        else
+            exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
+        fi
     else
         exec "${python_cmd}" "${LAUNCH_SCRIPT}" "$@"
     fi


### PR DESCRIPTION
Setting HSA_OVERRIDE_GFX_VERSION=10.3.0 for all AMD cards seems to break compatibility for polaris and vega cards so it should just be enabled on Navi