### PR TITLE
Experimental support for AMD Renoir

### DIFF
--- a/webui.sh
+++ b/webui.sh
@@ -105,10 +105,14 @@ fi
 
 # Check prerequisites
 gpu_info=$(lspci 2>/dev/null | grep VGA)
-if echo "$gpu_info" | grep -qE "Navi (1|2)"
-then
-    export HSA_OVERRIDE_GFX_VERSION=10.3.0
-fi
+case "$gpu_info" in
+    *"Navi 1"*|*"Navi 2"*) export HSA_OVERRIDE_GFX_VERSION=10.3.0
+    ;;
+    *"Renoir"*) export HSA_OVERRIDE_GFX_VERSION=9.0.0
+    ;;
+    *) 
+    ;;
+esac
 if echo "$gpu_info" | grep -q "AMD" && [[ -z "${TORCH_COMMAND}" ]]
 then
     export TORCH_COMMAND="pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/rocm5.2"


### PR DESCRIPTION
This change adds the GFX version 9.0.0 in order to use Renoir GPUs with at least 4 GB of VRAM (it's possible to increase the virtual VRAM from the BIOS settings of some vendors). This will only be possible if the total ram is more than 8GB or the system will become unresponsive on launch. This change also changes the GPU check to a case statement to be able to add and maintain more GPUs efficiently.

I've tested this change on a Lenovo Yoga Slim 7 with a 4700U APU and an unlocked bios that allows increasing the reserved ram for the GPU. Everything that works on other AMD GPUs seems to work fine (txt2img, img2img, inpaint...)and the generation time for a 512x512 image with sd 1.5 is about 1 to 3 minutes (way better than a CPU generation).

I've created this repo (https://github.com/DaniAndTheWeb/sd-data-amd-gpu) to try collecting as much information about AMD GPUs and stable diffusion that I'll use to add or improve support to the webui.

